### PR TITLE
Update base.less to reflect v.1.13.0 changes

### DIFF
--- a/styles/base.less
+++ b/styles/base.less
@@ -30,13 +30,13 @@ atom-text-editor .invisible-character,
 atom-text-editor .invisible-character {
     color: @syntax-invisible-character-color;
 }
-atom-text-editor .search-results .marker .region,
-atom-text-editor .search-results .marker .region {
+atom-text-editor .search-results .syntax--marker .region,
+atom-text-editor .search-results .syntax--marker .region {
     background-color: transparent;
     border: @syntax-result-marker-color;
 }
-atom-text-editor .search-results .marker.current-result .region,
-atom-text-editor .search-results .marker.current-result .region {
+atom-text-editor .search-results .syntax--marker.current-result .region,
+atom-text-editor .search-results .syntax--marker.current-result .region {
     border: @syntax-result-marker-color-selected;
 }
 atom-text-editor.is-focused .cursor,
@@ -272,7 +272,7 @@ atom-text-editor .line.cursor-line {
     color: rgba(255, 255, 255, 1);
     background-color: rgba(255, 149, 153, 1);
 }
-.sublimelinter.underline.illegal {
+.sublimelinter.syntax--underline.syntax--illegal {
     background-color: rgba(255, 73, 65, 1);
 }
 .sublimelinter.syntax--underline.syntax--warning {

--- a/styles/base.less
+++ b/styles/base.less
@@ -1,189 +1,190 @@
 @import "syntax-variables";
 atom-text-editor,
-:host {
+atom-text-editor{
     background-color: @syntax-background-color;
     color: @syntax-text-color;
 }
 atom-text-editor .gutter,
-:host .gutter {
+atom-text-editor .gutter {
     background-color: @syntax-gutter-background-color;
     color: @syntax-text-color;
 }
 atom-text-editor .gutter .line-number.cursor-line,
-:host .gutter .line-number.cursor-line {
+atom-text-editor .gutter .line-number.cursor-line {
     background-color: @syntax-gutter-background-color-selected;
     color: @syntax-gutter-text-color-selected;
 }
 atom-text-editor .gutter .line-number.cursor-line-no-selection,
-:host .gutter .line-number.cursor-line-no-selection {
+atom-text-editor .gutter .line-number.cursor-line-no-selection {
     color: @syntax-gutter-text-color-selected;
 }
 atom-text-editor .wrap-guide,
-:host .wrap-guide {
+atom-text-editor .wrap-guide {
     color: @syntax-wrap-guide-color;
 }
 atom-text-editor .indent-guide,
-:host .indent-guide {
+atom-text-editor .indent-guide {
     color: @syntax-indent-guide-color;
 }
 atom-text-editor .invisible-character,
-:host .invisible-character {
+atom-text-editor .invisible-character {
     color: @syntax-invisible-character-color;
 }
 atom-text-editor .search-results .marker .region,
-:host .search-results .marker .region {
+atom-text-editor .search-results .marker .region {
     background-color: transparent;
     border: @syntax-result-marker-color;
 }
 atom-text-editor .search-results .marker.current-result .region,
-:host .search-results .marker.current-result .region {
+atom-text-editor .search-results .marker.current-result .region {
     border: @syntax-result-marker-color-selected;
 }
 atom-text-editor.is-focused .cursor,
-:host(.is-focused) .cursor {
+atom-text-editor .cursor {
     border-color: @syntax-cursor-color;
 }
 atom-text-editor.is-focused .selection .region,
-:host(.is-focused) .selection .region {
+atom-text-editor .selection .region {
     background-color: @syntax-selection-color;
 }
 atom-text-editor.is-focused .line-number.cursor-line-no-selection,
 atom-text-editor.is-focused .line.cursor-line,
-:host(.is-focused) .line-number.cursor-line-no-selection,
-:host(.is-focused) .line.cursor-line {
+atom-text-editor .line-number.cursor-line-no-selection,
+atom-text-editor .line.cursor-line {
     background-color: rgba(0, 0, 0, 0.19); // FIXME
 }
-.variable.parameter.function {
+.syntax--variable.syntax--parameter.syntax--function {
     color: #e67e22;
 }
-.comment,
-.punctuation.definition.comment {
+.syntax--comment,
+.syntax--punctuation.syntax--definition.syntax--comment {
     color: @syntax-comments-color;
 }
-.punctuation.definition.string,
-.punctuation.definition.variable,
-.punctuation.definition.string,
-.punctuation.definition.parameters,
-.punctuation.definition.string,
-.punctuation.definition.array {
+.syntax--punctuation.syntax--definition.syntax--string,
+.syntax--punctuation.syntax--definition.syntax--variable,
+.syntax--punctuation.syntax--definition.syntax--string,
+.syntax--punctuation.syntax--definition.syntax--parameters,
+.syntax--punctuation.syntax--definition.syntax--string,
+.syntax--punctuation.syntax--definition.syntax--array {
     color: #d9f5dd; //FIXME
 }
-.none {
+.syntax--none {
     color: rgba(217, 245, 221, 1); // FIXME
 }
-.keyword.operator {
+.syntax--keyword.syntax--operator {
     color: rgba(217, 245, 221, 1); // FIXME
 }
-.keyword.operator,
-.constant.other.color,
-.keyword {
+.syntax--keyword.syntax--operator,
+.syntax--constant.syntax--other.syntax--color,
+.syntax--keyword {
     color: #e74c3c
 }
-.variable {
+.syntax--variable {
   color: #e67e22;
 
-  .punctuation.definition.variable {
+  .syntax--punctuation.syntax--definition.syntax--variable {
     color: inherit;
   }
 }
-.entity.name.function,
-.meta.require,
-.support.function.any-method,
-.meta.function-call,
-.support.function,
-.keyword.other.special-method,
-.meta.block-level {
+.syntax--entity.syntax--name.syntax--function,
+.syntax--meta.syntax--require,
+.syntax--support.syntax--function.syntax--any-method, 
+.syntax--meta.syntax--function-call, 
+.syntax--support.syntax--function, 
+.syntax--keyword.syntax--other.syntax--special-method, 
+.syntax--meta.syntax--block-level {
     color: #2ecc71;
 }
-.support.class,
-.entity.name.class,
-.entity.name.type.class {
+.syntax--support.syntax--class,
+.syntax--entity.syntax--name.syntax--class,
+.syntax--entity.syntax--name.syntax--type.syntax--class {
     color: #3498db;
 }
-.meta.class {
+.syntax--meta.syntax--class {
     color: #1abc9c;
 }
-.keyword.other.special-method {
+.syntax--keyword.syntax--other.syntax--special-method {
     color: #82b1ff; // FIXME
 }
-.storage {
+.syntax--storage {
     color: #3498db;
 }
-.support.function,
-.support.constant,
-.meta.tag,
-.punctuation.definition.tag,
-.punctuation.separator.inheritance.php,
-.punctuation.definition.tag.html,
-.punctuation.definition.tag.begin.html,
-.punctuation.definition.tag.end.html {
+.syntax--support.syntax--function, 
+.syntax--support.syntax--constant, 
+.syntax--meta.syntax--tag, 
+.syntax--punctuation.syntax--definition.syntax--tag, 
+.syntax--punctuation.syntax--separator.syntax--inheritance.syntax--php, 
+.syntax--punctuation.syntax--definition.syntax--tag.syntax--html, 
+.syntax--punctuation.syntax--definition.syntax--tag.syntax--begin.syntax--html,
+.syntax--punctuation.syntax--definition.syntax--tag.syntax--end.syntax--html {
     color: #2ecc71;
 }
-.string,
-.constant.other.symbol,
-.entity.other.inherited-class {
+.syntax--string,
+.syntax--constant.syntax--other.syntax--symbol, 
+.syntax--entity.syntax--other.syntax--inherited-class {
     color: #f1c40f;
 }
-.constant.numeric {
+.syntax--constant.syntax--numeric {
     color: #6c71c4;
 }
-.none {
+.syntax--none {
     color: #6c71c4;
 }
-.none {
+.syntax--none {
     color: #6c71c4;
 }
-.constant {
+.syntax--constant {
     color: #6c71c4;
 }
-.entity.name.tag {
+.syntax--entity.syntax--name.syntax--tag {
     color: #2ecc71;
 }
-.entity.other.attribute-name {
+.syntax--entity.syntax--other.syntax--attribute-name {
     color: #2ecc71;
 }
-.entity.other.attribute-name.id {
+.syntax--entity.syntax--other.syntax--attribute-name.syntax--id {
     color: #1abc9c;
 }
-.meta.selector {
+.syntax--meta.syntax--selector {
     color: #3498db;
 }
-.none {
+.syntax--none {
     color: #6c71c4;
 }
-.markup.heading .punctuation.definition.heading,
-.entity.name.section {
+.syntax--markup.syntax--heading .syntax--punctuation.syntax--definition.syntax--heading,
+.syntax--entity.syntax--name.syntax--section {
     color: #2ecc71;
 }
-.keyword.other.unit {
+.syntax--keyword.syntax--other.syntax--unit {
     color: #d7503c;
 }
-.markup.bold,
-.punctuation.definition.bold {
+.syntax--markup.syntax--bold,
+.syntax--punctuation.syntax--definition.syntax--bold {
     font-weight: bold;
     color: #F8F8F8;
 }
-.markup.italic,
-.punctuation.definition.italic {
+.syntax--markup.syntax--italic,
+.syntax--punctuation.syntax--definition.syntax--italic {
     font-style: italic;
     color: #233345;
 }
-.markup.raw.inline, .markup.raw {
+.syntax--markup.syntax--raw.syntax--inline,
+.syntax--markup.syntax--raw {
     color: #f1c40f;
 }
-.string.other.link,
-.punctuation.definition.string.end.markdown {
+.syntax--string.syntax--other.syntax--link,
+.syntax--punctuation.syntax--definition.syntax--string.syntax--end.syntax--markdown {
     color: #d7503c;
 }
 [data-grammar*="gfm"]::shadow {
-    .markup.underline.link {
+    .syntax--markup.syntax--underline.syntax--link {
         color: #d7503c;
 
-        span.punctuation {
+        span.syntax--punctuation {
             color: #d7503c;
         }
     }
-    .markup.strike {
+    .syntax--markup.syntax--strike {
         position: relative;
         color: fade(@syntax-text-color, 50%);
 
@@ -197,68 +198,69 @@ atom-text-editor.is-focused .line.cursor-line,
             background-color: fade(@syntax-text-color, 20%);
         }
     }
-    .table .border {
+    .syntax--table .syntax--border {
         color: fade(@syntax-text-color, 50%);
     }
-    .markup.heading {
+    .syntax--markup.syntax--heading {
         color: #3498db;
     }
-    .punctuation.definition.begin, .punctuation.definition.end {
+    .syntax--punctuation.syntax--definition.syntax--begin,
+    .syntax--punctuation.syntax--definition.syntax--end {
         color: #3498db;
     }
-    .punctuation.definition.begin + span:not(.function.parameter) {
+    .syntax--punctuation.syntax--definition.syntax--begin + span:not(.function.parameter) {
         color: lighten(#82b1ff, 5%);
     }
 }
-.meta.link {
+.syntax--meta.syntax--link {
     color: #d7503c;
 }
-.markup.list {
+.syntax--markup.syntax--list {
     color: #2ecc71;
 }
-.markup.quote {
+.syntax--markup.syntax--quote {
     color: #f77669;
 }
-.meta.separator {
+.syntax--meta.syntax--separator {
     color: #5eebb8;
     background-color: #233345;
 }
-.markup.inserted {
+.syntax--markup.syntax--inserted {
     color: #FFCC66;
 }
-.markup.deleted {
+.syntax--markup.syntax--deleted {
     color: #F2777A;
 }
-.markup.changed {
+.syntax--markup.syntax--changed {
     color: #CC99CC;
 }
-.constant.other.color,
-.meta.property-value .support.constant.named-color.css {
+.syntax--constant.syntax--other.syntax--color,
+.syntax--meta.syntax--property-value .syntax--support.syntax--constant.named-color.syntax--css {
     color: #FFCC66;
 }
-.string.regexp {
+.syntax--string.syntax--regexp {
     color: #3498db;
 }
-.constant.character.escape {
+.syntax--constant.syntax--character.syntax--escape {
     color: #3498db;
 }
-.punctuation.section.embedded,
-.variable.interpolation {
+.syntax--punctuation.syntax--section.syntax--embedded,
+.syntax--variable.syntax--interpolation {
     color: #e67e22;
 }
-.invalid.illegal {
+.syntax--invalid.syntax--illegal {
     color: rgba(255, 255, 255, 1);
     background-color: #ec5f67;
 }
-.invalid.broken {
+.syntax--invalid.syntax--broken {
     color: rgba(2, 14, 20, 1);
     background-color: #f77669;
 }
-.invalid.deprecated {
+.syntax--invalid.syntax--deprecated {
     color: rgba(255, 255, 255, 1);
     background-color: #e74c3c;
 }
-.invalid.unimplemented {
+.syntax--invalid.syntax--unimplemented {
     color: rgba(255, 255, 255, 1);
     background-color: #2ecc71;
 }
@@ -266,74 +268,74 @@ atom-text-editor.is-focused .line.cursor-line,
     color: rgba(123, 81, 87, 1);
     background-color: rgba(255, 255, 247, 1);
 }
-.sublimelinter.outline.illegal {
+.sublimelinter.outline.syntax--illegal {
     color: rgba(255, 255, 255, 1);
     background-color: rgba(255, 149, 153, 1);
 }
 .sublimelinter.underline.illegal {
     background-color: rgba(255, 73, 65, 1);
 }
-.sublimelinter.outline.warning {
+.sublimelinter.syntax--underline.syntax--warning {
     color: rgba(255, 255, 255, 1);
     background-color: #e74c3c;
 }
-.sublimelinter.underline.warning {
+.sublimelinter.syntax--underline.syntax--warning {
     background-color: rgba(255, 73, 65, 1);
 }
-.sublimelinter.outline.violation {
+.sublimelinter.syntax--outline.violation {
     color: rgba(255, 255, 255, 1);
     background-color: rgba(255, 255, 255, 0.2);
 }
-.sublimelinter.underline.violation {
+.sublimelinter.syntax--underline.violation {
     background-color: rgba(255, 73, 65, 1);
 }
-.sublimelinter.mark.error {
+.sublimelinter.syntax--mark.syntax--error {
     color: #e74c3c;
 }
-.sublimelinter.mark.warning {
+.sublimelinter.syntax--mark.syntax--warning {
     color: #f1c40f;
 }
 .sublimelinter.gutter-mark {
     color: rgba(255, 255, 255, 1);
 }
-.markup.deleted.git_gutter {
+.syntax--markup.syntax--deleted.git_gutter {
     color: #e74c3c;
 }
-.markup.changed.git_gutter {
+.syntax--markup.syntax--changed.git_gutter {
     color: #f1c40f;
 }
-.markup.inserted.git_gutter {
+.syntax--markup.syntax--inserted.git_gutter {
     color: #c3e88d;
 }
-.markup.ignored.git_gutter {
+.syntax--markup.syntax--ignored.git_gutter {
     color: #546e7a;
 }
-.comment.line.double-slash .punctuation.definition.comment,
-.meta.structure.array .comment.block.json .punctuation.definition.comment {
+.syntax--comment.line.syntax--double-slash .syntax--punctuation.syntax--definition.syntax--comment,
+.syntax--meta.syntax--structure.syntax--array .syntax--comment.syntax--block.syntax--json .syntax--punctuation.syntax--definition.syntax--comment {
     color: @syntax-comments-color;
 }
-.support.type.property-name {
+.syntax--support.syntax--type.syntax--property-name {
     color: #80cbc4;
 }
-.meta.property-list .meta.property-name {
+.syntax--meta.syntax--property-list .syntax--meta.syntax--property-name {
     color: #80cbc4;
 }
-.source.css .keyword.other.unit,
-.source.less .keyword.other.unit,
-.source.scss .keyword.other.unit,
-.source.sass .keyword.other.unit {
+.syntax--source.syntax--css .syntax--keyword.syntax--other.syntax--unit,
+.syntax--source.syntax--less .syntax--keyword.syntax--other.syntax--unit,
+.syntax--source.syntax--scss .syntax--keyword.syntax--other.syntax--unit,
+.syntax--source.syntax--sass .syntax--keyword.syntax--other.syntax--unit {
     color: #f1c40f;
 }
-.entity.other.less.mixin {
+.syntax--entity.syntax--other.syntax--less.syntax--mixin {
     color: #d7503c;
 }
-.constant.other.color.rgb-value .punctuation.definition.constant {
+.syntax--constant.syntax--other.syntax--color.syntax--rgb-value .syntax--punctuation.syntax--definition.syntax--constant {
     color: #e74c3c;
 }
-.meta.attribute-selector .string.unquoted.attribute-value {
+.syntax--meta.syntax--attribute-selector .syntax--string.syntax--unquoted.syntax--attribute-value {
     color: #c3e88d;
 }
-.meta.attribute-selector .entity.other.attribute-name.attribute {
+.syntax--meta.syntax--attribute-selector .syntax--entity.syntax--other.syntax--attribute-name.syntax--attribute {
     color: #e74c3c;
 }
 .bracket-matcher .region {


### PR DESCRIPTION
From Atom's deprecation message:

> Starting from Atom v1.13.0, the contents of atom-text-editor elements are no
> longer encapsulated within a shadow DOM boundary. This means you should
> stop using :host and ::shadow pseudo-selectors, and prepend all your syntax
> selectors with syntax--. [...] Automatic translation of selectors will be
> removed in a few release cycles to minimize startup time.

This patch updates the syntax file to match Atom specifications.